### PR TITLE
Expanded out of context public replies

### DIFF
--- a/RegEx-Filters.md
+++ b/RegEx-Filters.md
@@ -21,7 +21,7 @@ Annoyances
 * `\b\w+\*+\w\b` — Tweets censored for no f**king reason ([@jordanekay](http://twitter.com/jordanekay))
 * `(?i)checked.*in` - I checked in at... ([@jonohunt](http://twitter.com/jonohunt))
 * `\n{3,}` — Tweets with 3 or more line breaks. ([@justin](http://twitter.com/justin))
-* `^\.@` — Out of context public replies. ([@grahamwetzler](http://twitter.com/grahamwetzler))
+* `^\.\s?@` — Out of context public replies. ([@grahamwetzler](http://twitter.com/grahamwetzler) / [@ashfurrow](http://twitter.com/ashfurrow))
 * is my new jam – No one cares what your new jam is PLEASE SHUT UP GOSH ([@MikeBeas](http://twitter.com/MikeBeas))
 * is my insanely catch song of the day ([@MikeBeas](http://twitter.com/MikeBeas))
 


### PR DESCRIPTION
People sometimes put a space in between the dot and the `@`. This catches those, too. 